### PR TITLE
Feat/winston sentry dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3320,13 +3320,15 @@
         }
       }
     },
-    "winston-raven-sentry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/winston-raven-sentry/-/winston-raven-sentry-2.0.0.tgz",
-      "integrity": "sha512-Tp2U3hRw8FGKJPphRkunkZ2abLYguYY0yzKSp3vsWYRTeuIyhBTfXYOvaXxkIpjh3hHaNRPqb31OnbjdhRlBYw==",
+    "winston-sentry-raven-transport": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/winston-sentry-raven-transport/-/winston-sentry-raven-transport-1.0.3.tgz",
+      "integrity": "sha512-RmIWl343byPGc9uXGm4g2XhnKFRSbJWGSTXcOpjvEYwKHgWM5fC4EOsPAZvhMy7O7FRBvXBIvphWyQxNnd1zGA==",
       "requires": {
-        "lodash": "^4.17.4",
-        "raven": "^2.1.0"
+        "lodash": "^4.17.11",
+        "raven": "^2.6.4",
+        "winston": "^3.2.1",
+        "winston-transport": "^4.3.0"
       }
     },
     "winston-transport": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@epsor/logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@elastic/elasticsearch": "^7.1.0",
     "winston": "^3.2.1",
     "winston-elasticsearch": "^0.7.12",
-    "winston-raven-sentry": "^2.0.0"
+    "winston-sentry-raven-transport": "^1.0.3"
   },
   "homepage": "https://github.com/Epsor/logger#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epsor/logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Epsor logging superset over Winston for console and elasticsearch",
   "main": "dist/index.js",
   "private": false,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import winston from 'winston';
 import ElasticsearchTransport from 'winston-elasticsearch';
-import SentryTransport from 'winston-raven-sentry';
+import SentryTransport from 'winston-sentry-raven-transport';
 import { Client } from '@elastic/elasticsearch';
 
 const useElasticsearch =
@@ -48,6 +48,7 @@ const esTransportOptions = {
 
 const sentryTransportOptions = {
   dsn: process.env.SENTRY_DSN,
+  name: 'winston-sentry',
   logger: 'winston-sentry',
   server_name: process.env.SERVICE_NAME,
   environment: process.env.ENVIRONMENT,


### PR DESCRIPTION
Switch from [https://github.com/niftylettuce/winston-raven-sentry](https://github.com/niftylettuce/winston-raven-sentry) to https://github.com/aandrewww/winston-sentry-raven-transport to use winston v3.0.0